### PR TITLE
Fix validation for partial updates

### DIFF
--- a/lib/model.ts
+++ b/lib/model.ts
@@ -29,6 +29,17 @@ export class Model<T extends Record<string, any>> { // Ensure T is an object
         return true;
     }
 
+    validatePartial(data: Partial<T>): boolean {
+        const partialSchema: any = { ...this.schema };
+        delete partialSchema.required;
+        const validate = ajv.compile(partialSchema);
+        const valid = validate(data);
+        if (!valid) {
+            throw new Error(`Schema validation error: ${JSON.stringify(validate.errors)}`);
+        }
+        return true;
+    }
+
     getCollectionId(): string {
         return this.collectionId;
     }
@@ -48,7 +59,7 @@ export class Model<T extends Record<string, any>> { // Ensure T is an object
     }
 
     async updateDocument(documentId: string, data: Partial<T>): Promise<AppwriteModels.Document> {
-        this.validate(data as T); // Validate the data against the schema
+        this.validatePartial(data); // Validate partial data against the schema
         return await this.database.updateDocument(this.databaseId, this.collectionId, documentId, data);
     }
 

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -31,7 +31,7 @@ export class Repository<T extends Record<string, any>> {
     }
 
     async update(documentId: string, data: Partial<T>) {
-        this.model.validate(data as T); // Ensure data is validated
+        this.model.validatePartial(data); // Validate partial data
         return await this.database.updateDocument(
             this.model.getDatabaseId(),
             this.model.getCollectionId(),


### PR DESCRIPTION
## Summary
- add `validatePartial` in `Model`
- validate partial data when updating documents

## Testing
- `npm run build`
- `npm test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff01e022c833087b2d1746a5d09b3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved validation for partial updates, allowing users to update only specific fields without requiring complete data.

- **Bug Fixes**
  - Resolved issues with partial updates failing validation when not all fields were provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->